### PR TITLE
Make chat room name be display name of other user

### DIFF
--- a/src/__tests__/ChatRoom.test.js
+++ b/src/__tests__/ChatRoom.test.js
@@ -242,7 +242,9 @@ test("Render chat room name", async () => {
     screen.getByPlaceholderText("Potatoes can't talk... but you can!")
   );
 
-  expect(screen.getByTestId("room-name")).toHaveTextContent(otherUserDocData.displayName);
+  expect(screen.getByTestId("room-name")).toHaveTextContent(
+    otherUserDocData.displayName
+  );
 });
 
 test("Render user list", async () => {

--- a/src/__tests__/ChatRoom.test.js
+++ b/src/__tests__/ChatRoom.test.js
@@ -468,7 +468,7 @@ test("Switch rooms", async () => {
   const user3Button = screen.getByText(user3DocData.displayName);
   fireEvent.click(user3Button);
   await waitFor(() => expect(firestoreMock.get).toBeCalledTimes(2));
-  // now user2 should appear once but user3 should now appear in user list and room name
+  // now user2 should appear once but user3 should appear in user list and room name
   await waitFor(() =>
     expect(screen.getAllByText(user2DocData.displayName).length).toBe(1)
   );

--- a/src/__tests__/ChatRoom.test.js
+++ b/src/__tests__/ChatRoom.test.js
@@ -243,7 +243,7 @@ test("Render chat room name", async () => {
   );
 
   const chatRoomTitleElement = screen.getByTestId("room-name");
-  expect(chatRoomTitleElement.children == otherUserDocData.displayName);
+  expect(chatRoomTitleElement.children === otherUserDocData.displayName);
 });
 
 test("Render user list", async () => {
@@ -287,10 +287,10 @@ test("Render user list", async () => {
 
   // first test user should appear once in user list and once as room name
   await waitFor(() =>
-    expect(screen.getAllByText(docData1.displayName).length == 2)
+    expect(screen.getAllByText(docData1.displayName).length === 2)
   );
   await waitFor(() =>
-    expect(screen.getAllByText(docData2.displayName).length == 1)
+    expect(screen.getAllByText(docData2.displayName).length === 1)
   );
 });
 
@@ -332,10 +332,10 @@ test("Search user", async () => {
   // get all users
   // first test user should appear once in user list and once as room name
   await waitFor(() =>
-    expect(screen.getAllByText(docData1.displayName).length == 2)
+    expect(screen.getAllByText(docData1.displayName).length === 2)
   );
   await waitFor(() =>
-    expect(screen.getAllByText(docData2.displayName).length == 1)
+    expect(screen.getAllByText(docData2.displayName).length === 1)
   );
 
   // mock search user return
@@ -349,7 +349,7 @@ test("Search user", async () => {
     expect(screen.queryByText(docData2.displayName)).toBeNull()
   );
   // first test user should still appear twice, in user list and as room name
-  expect(screen.getAllByText(docData1.displayName).length == 2);
+  expect(screen.getAllByText(docData1.displayName).length === 2);
 });
 
 test("Switch rooms", async () => {
@@ -439,10 +439,10 @@ test("Switch rooms", async () => {
   // get all users
   // user2 should appear once in user list and once as room name
   await waitFor(() =>
-    expect(screen.getAllByText(user2DocData.displayName).length == 2)
+    expect(screen.getAllByText(user2DocData.displayName).length === 2)
   );
   await waitFor(() =>
-    expect(screen.getAllByText(user3DocData.displayName).length == 1)
+    expect(screen.getAllByText(user3DocData.displayName).length === 1)
   );
   expect(screen.queryByText(user.displayName)).toBeNull();
 
@@ -464,10 +464,10 @@ test("Switch rooms", async () => {
   await waitFor(() => expect(firestoreMock.get).toBeCalledTimes(2));
   // now user2 should appear once but user3 should now appear in user list and room name
   await waitFor(() =>
-    expect(screen.getAllByText(user2DocData.displayName).length == 1)
+    expect(screen.getAllByText(user2DocData.displayName).length === 1)
   );
   await waitFor(() =>
-    expect(screen.getAllByText(user3DocData.displayName).length == 2)
+    expect(screen.getAllByText(user3DocData.displayName).length === 2)
   );
   await waitFor(() => expect(screen.queryByText(message1)).toBeNull());
   await waitFor(() => screen.getByText(message2));

--- a/src/__tests__/ChatRoom.test.js
+++ b/src/__tests__/ChatRoom.test.js
@@ -243,8 +243,9 @@ test("Render user list", async () => {
     screen.getByPlaceholderText("Potatoes can't talk... but you can!")
   );
 
-  await waitFor(() => screen.getByText(docData1.displayName));
-  await waitFor(() => screen.getByText(docData2.displayName));
+  // first test user should appear once in user list and once as room name
+  await waitFor(() => expect(screen.getAllByText(docData1.displayName).length == 2));
+  await waitFor(() => expect(screen.getAllByText(docData2.displayName).length == 1));
 });
 
 test("Search user", async () => {
@@ -283,8 +284,9 @@ test("Search user", async () => {
 
   await waitFor(() => screen.getByPlaceholderText("Search"));
   // get all users
-  await waitFor(() => screen.getByText(docData1.displayName));
-  await waitFor(() => screen.getByText(docData2.displayName));
+  // first test user should appear once in user list and once as room name
+  await waitFor(() => expect(screen.getAllByText(docData1.displayName).length == 2));
+  await waitFor(() => expect(screen.getAllByText(docData2.displayName).length == 1));
 
   // mock search user return
   firestoreMock.get = jest.fn(() => Promise.resolve([docResult1]));
@@ -293,10 +295,11 @@ test("Search user", async () => {
   const searchInput = screen.getByPlaceholderText("Search");
   fireEvent.input(searchInput, { target: { value: "test" } });
 
-  await waitFor(() => screen.getByText(docData1.displayName));
   await waitFor(() =>
     expect(screen.queryByText(docData2.displayName)).toBeNull()
   );
+  // first test user should still appear twice, in user list and as room name
+  expect(screen.getAllByText(docData1.displayName).length == 2)
 });
 
 test("Switch rooms", async () => {
@@ -384,8 +387,9 @@ test("Switch rooms", async () => {
   await waitFor(() => expect(firestoreMock.get).toBeCalledTimes(3));
 
   // get all users
-  await waitFor(() => screen.getByText(user2DocData.displayName));
-  await waitFor(() => screen.getByText(user3DocData.displayName));
+  // user2 should appear once in user list and once as room name
+  await waitFor(() => expect(screen.getAllByText(user2DocData.displayName).length == 2));
+  await waitFor(() => expect(screen.getAllByText(user3DocData.displayName).length == 1));
   expect(screen.queryByText(user.displayName)).toBeNull();
 
   await waitFor(() => screen.getByText(message1));
@@ -404,6 +408,9 @@ test("Switch rooms", async () => {
   const user3Button = screen.getByText(user3DocData.displayName);
   fireEvent.click(user3Button);
   await waitFor(() => expect(firestoreMock.get).toBeCalledTimes(2));
+  // now user2 should appear once but user3 should now appear in user list and room name
+  await waitFor(() => expect(screen.getAllByText(user2DocData.displayName).length == 1));
+  await waitFor(() => expect(screen.getAllByText(user3DocData.displayName).length == 2));
   await waitFor(() => expect(screen.queryByText(message1)).toBeNull());
   await waitFor(() => screen.getByText(message2));
 });

--- a/src/__tests__/ChatRoom.test.js
+++ b/src/__tests__/ChatRoom.test.js
@@ -66,6 +66,11 @@ test("Can log out", async () => {
       <ChatRoom />
     </Router>
   );
+
+  await waitFor(() =>
+    screen.getByPlaceholderText("Potatoes can't talk... but you can!")
+  );
+
   const button = screen.getByText("Log out");
   fireEvent.click(button);
   await waitFor(() => expect(history.location.pathname).toEqual("/"));

--- a/src/__tests__/ChatRoom.test.js
+++ b/src/__tests__/ChatRoom.test.js
@@ -204,6 +204,48 @@ test("Send message button click tries to update database", async () => {
   await waitFor(() => expect(messageInput.value).toBe(""));
 });
 
+test("Render chat room name", async () => {
+  const testRoomId = "test_room_id";
+  user.roomIds = [testRoomId];
+
+  const otherUserDocData = {
+    displayName: "Other test user",
+    online: true,
+    roomIds: [testRoomId],
+    username: "other_test_user",
+  };
+  const otherUserDocResult = {
+    data: () => otherUserDocData,
+  };
+
+  const roomDocResult = {
+    id: testRoomId,
+  };
+
+  firestoreMock.get = jest
+    .fn()
+    // first call in getUsers, where there is only one other user
+    .mockResolvedValueOnce([otherUserDocResult])
+    // second call in getFirstRoom to get the current room
+    .mockResolvedValueOnce([roomDocResult])
+    // third call in getInitMessages, representing no initial messages
+    .mockResolvedValueOnce([])
+  jest.spyOn(firebase, "firestore").mockImplementation(() => firestoreMock);
+
+  render(
+    <Router history={history}>
+      <ChatRoom />
+    </Router>
+  );
+
+  await waitFor(() =>
+    screen.getByPlaceholderText("Potatoes can't talk... but you can!")
+  );
+
+  const chatRoomTitleElement = screen.getByTestId('room-name');
+  expect(chatRoomTitleElement.children == otherUserDocData.displayName)
+});
+
 test("Render user list", async () => {
   // console.log("Starting test: Render user list");
 

--- a/src/__tests__/ChatRoom.test.js
+++ b/src/__tests__/ChatRoom.test.js
@@ -229,7 +229,7 @@ test("Render chat room name", async () => {
     // second call in getFirstRoom to get the current room
     .mockResolvedValueOnce([roomDocResult])
     // third call in getInitMessages, representing no initial messages
-    .mockResolvedValueOnce([])
+    .mockResolvedValueOnce([]);
   jest.spyOn(firebase, "firestore").mockImplementation(() => firestoreMock);
 
   render(
@@ -242,8 +242,8 @@ test("Render chat room name", async () => {
     screen.getByPlaceholderText("Potatoes can't talk... but you can!")
   );
 
-  const chatRoomTitleElement = screen.getByTestId('room-name');
-  expect(chatRoomTitleElement.children == otherUserDocData.displayName)
+  const chatRoomTitleElement = screen.getByTestId("room-name");
+  expect(chatRoomTitleElement.children == otherUserDocData.displayName);
 });
 
 test("Render user list", async () => {
@@ -286,8 +286,12 @@ test("Render user list", async () => {
   );
 
   // first test user should appear once in user list and once as room name
-  await waitFor(() => expect(screen.getAllByText(docData1.displayName).length == 2));
-  await waitFor(() => expect(screen.getAllByText(docData2.displayName).length == 1));
+  await waitFor(() =>
+    expect(screen.getAllByText(docData1.displayName).length == 2)
+  );
+  await waitFor(() =>
+    expect(screen.getAllByText(docData2.displayName).length == 1)
+  );
 });
 
 test("Search user", async () => {
@@ -327,8 +331,12 @@ test("Search user", async () => {
   await waitFor(() => screen.getByPlaceholderText("Search"));
   // get all users
   // first test user should appear once in user list and once as room name
-  await waitFor(() => expect(screen.getAllByText(docData1.displayName).length == 2));
-  await waitFor(() => expect(screen.getAllByText(docData2.displayName).length == 1));
+  await waitFor(() =>
+    expect(screen.getAllByText(docData1.displayName).length == 2)
+  );
+  await waitFor(() =>
+    expect(screen.getAllByText(docData2.displayName).length == 1)
+  );
 
   // mock search user return
   firestoreMock.get = jest.fn(() => Promise.resolve([docResult1]));
@@ -341,7 +349,7 @@ test("Search user", async () => {
     expect(screen.queryByText(docData2.displayName)).toBeNull()
   );
   // first test user should still appear twice, in user list and as room name
-  expect(screen.getAllByText(docData1.displayName).length == 2)
+  expect(screen.getAllByText(docData1.displayName).length == 2);
 });
 
 test("Switch rooms", async () => {
@@ -430,8 +438,12 @@ test("Switch rooms", async () => {
 
   // get all users
   // user2 should appear once in user list and once as room name
-  await waitFor(() => expect(screen.getAllByText(user2DocData.displayName).length == 2));
-  await waitFor(() => expect(screen.getAllByText(user3DocData.displayName).length == 1));
+  await waitFor(() =>
+    expect(screen.getAllByText(user2DocData.displayName).length == 2)
+  );
+  await waitFor(() =>
+    expect(screen.getAllByText(user3DocData.displayName).length == 1)
+  );
   expect(screen.queryByText(user.displayName)).toBeNull();
 
   await waitFor(() => screen.getByText(message1));
@@ -451,8 +463,12 @@ test("Switch rooms", async () => {
   fireEvent.click(user3Button);
   await waitFor(() => expect(firestoreMock.get).toBeCalledTimes(2));
   // now user2 should appear once but user3 should now appear in user list and room name
-  await waitFor(() => expect(screen.getAllByText(user2DocData.displayName).length == 1));
-  await waitFor(() => expect(screen.getAllByText(user3DocData.displayName).length == 2));
+  await waitFor(() =>
+    expect(screen.getAllByText(user2DocData.displayName).length == 1)
+  );
+  await waitFor(() =>
+    expect(screen.getAllByText(user3DocData.displayName).length == 2)
+  );
   await waitFor(() => expect(screen.queryByText(message1)).toBeNull());
   await waitFor(() => screen.getByText(message2));
 });

--- a/src/__tests__/ChatRoom.test.js
+++ b/src/__tests__/ChatRoom.test.js
@@ -243,7 +243,7 @@ test("Render chat room name", async () => {
   );
 
   const chatRoomTitleElement = screen.getByTestId("room-name");
-  expect(chatRoomTitleElement.children === otherUserDocData.displayName);
+  expect(chatRoomTitleElement.textContent).toBe(otherUserDocData.displayName);
 });
 
 test("Render user list", async () => {
@@ -287,10 +287,10 @@ test("Render user list", async () => {
 
   // first test user should appear once in user list and once as room name
   await waitFor(() =>
-    expect(screen.getAllByText(docData1.displayName).length === 2)
+    expect(screen.getAllByText(docData1.displayName).length).toBe(2)
   );
   await waitFor(() =>
-    expect(screen.getAllByText(docData2.displayName).length === 1)
+    expect(screen.getAllByText(docData2.displayName).length).toBe(1)
   );
 });
 
@@ -332,10 +332,10 @@ test("Search user", async () => {
   // get all users
   // first test user should appear once in user list and once as room name
   await waitFor(() =>
-    expect(screen.getAllByText(docData1.displayName).length === 2)
+    expect(screen.getAllByText(docData1.displayName).length).toBe(2)
   );
   await waitFor(() =>
-    expect(screen.getAllByText(docData2.displayName).length === 1)
+    expect(screen.getAllByText(docData2.displayName).length).toBe(1)
   );
 
   // mock search user return
@@ -349,7 +349,7 @@ test("Search user", async () => {
     expect(screen.queryByText(docData2.displayName)).toBeNull()
   );
   // first test user should still appear twice, in user list and as room name
-  expect(screen.getAllByText(docData1.displayName).length === 2);
+  expect(screen.getAllByText(docData1.displayName).length).toBe(2);
 });
 
 test("Switch rooms", async () => {
@@ -439,10 +439,10 @@ test("Switch rooms", async () => {
   // get all users
   // user2 should appear once in user list and once as room name
   await waitFor(() =>
-    expect(screen.getAllByText(user2DocData.displayName).length === 2)
+    expect(screen.getAllByText(user2DocData.displayName).length).toBe(2)
   );
   await waitFor(() =>
-    expect(screen.getAllByText(user3DocData.displayName).length === 1)
+    expect(screen.getAllByText(user3DocData.displayName).length).toBe(1)
   );
   expect(screen.queryByText(user.displayName)).toBeNull();
 
@@ -464,10 +464,10 @@ test("Switch rooms", async () => {
   await waitFor(() => expect(firestoreMock.get).toBeCalledTimes(2));
   // now user2 should appear once but user3 should now appear in user list and room name
   await waitFor(() =>
-    expect(screen.getAllByText(user2DocData.displayName).length === 1)
+    expect(screen.getAllByText(user2DocData.displayName).length).toBe(1)
   );
   await waitFor(() =>
-    expect(screen.getAllByText(user3DocData.displayName).length === 2)
+    expect(screen.getAllByText(user3DocData.displayName).length).toBe(2)
   );
   await waitFor(() => expect(screen.queryByText(message1)).toBeNull());
   await waitFor(() => screen.getByText(message2));

--- a/src/__tests__/ChatRoom.test.js
+++ b/src/__tests__/ChatRoom.test.js
@@ -242,8 +242,7 @@ test("Render chat room name", async () => {
     screen.getByPlaceholderText("Potatoes can't talk... but you can!")
   );
 
-  const chatRoomTitleElement = screen.getByTestId("room-name");
-  expect(chatRoomTitleElement.textContent).toBe(otherUserDocData.displayName);
+  expect(screen.getByTestId("room-name")).toHaveTextContent(otherUserDocData.displayName);
 });
 
 test("Render user list", async () => {

--- a/src/modules/ChatRoom.js
+++ b/src/modules/ChatRoom.js
@@ -20,8 +20,10 @@ class ChatRoom extends React.Component {
       message: "",
       messages: [],
       user: user,
+      otherUser: null,
       users: [],
       keyword: "",
+      roomName: ""
     };
     this.dummy = createRef();
     this.handleChange = this.handleChange.bind(this);
@@ -77,6 +79,7 @@ class ChatRoom extends React.Component {
     this.setState({
       otherUser: otherUser,
       roomId: roomId,
+      roomName: otherUser.displayName,
       messages: [],
     });
     this.getInitMessages().then(() => {
@@ -172,6 +175,7 @@ class ChatRoom extends React.Component {
     let firstUser = this.state.users[0];
     this.setState({
       otherUser: firstUser,
+      roomName: firstUser.displayName
     });
     let participants = [this.state.user.username, firstUser.username].sort();
 
@@ -338,7 +342,7 @@ class ChatRoom extends React.Component {
           >
             Log out
           </button>
-          <h3>Chat Room</h3>
+          <h3 data-testid="room-name">{ this.state.roomName }</h3>
           <div className="chat-messages">
             {this.state.messages &&
               this.state.messages

--- a/src/modules/ChatRoom.js
+++ b/src/modules/ChatRoom.js
@@ -23,7 +23,7 @@ class ChatRoom extends React.Component {
       otherUser: null,
       users: [],
       keyword: "",
-      roomName: ""
+      roomName: "",
     };
     this.dummy = createRef();
     this.handleChange = this.handleChange.bind(this);
@@ -175,7 +175,7 @@ class ChatRoom extends React.Component {
     let firstUser = this.state.users[0];
     this.setState({
       otherUser: firstUser,
-      roomName: firstUser.displayName
+      roomName: firstUser.displayName,
     });
     let participants = [this.state.user.username, firstUser.username].sort();
 
@@ -342,7 +342,7 @@ class ChatRoom extends React.Component {
           >
             Log out
           </button>
-          <h3 data-testid="room-name">{ this.state.roomName }</h3>
+          <h3 data-testid="room-name">{this.state.roomName}</h3>
           <div className="chat-messages">
             {this.state.messages &&
               this.state.messages

--- a/src/modules/ChatRoom.js
+++ b/src/modules/ChatRoom.js
@@ -23,7 +23,7 @@ class ChatRoom extends React.Component {
       otherUser: null,
       users: [],
       keyword: "",
-      roomName: "",
+      roomName: "Chat Room",
     };
     this.dummy = createRef();
     this.handleChange = this.handleChange.bind(this);

--- a/src/modules/ChatRoom.js
+++ b/src/modules/ChatRoom.js
@@ -3,6 +3,7 @@ import firebase from "firebase/app";
 import { withRouter } from "react-router-dom";
 import ChatMessage from "./ChatMessage";
 import User from "./User";
+import Loading from "./Loading";
 
 /**
  * This is the ChatRoom Component
@@ -24,6 +25,7 @@ class ChatRoom extends React.Component {
       users: [],
       keyword: "",
       roomName: "Chat Room",
+      loading: true
     };
     this.dummy = createRef();
     this.handleChange = this.handleChange.bind(this);
@@ -48,6 +50,8 @@ class ChatRoom extends React.Component {
       this.getMessages().then(() => {
         this.scrollToBottom();
       });
+
+      this.setState({ loading: false });
     }
   }
 
@@ -308,7 +312,9 @@ class ChatRoom extends React.Component {
   }
 
   render() {
-    return (
+    return this.state.loading ? (
+      <Loading />
+    ) : (
       <div className="main">
         <div className="user-list-wrapper">
           <h3>People</h3>

--- a/src/modules/ChatRoom.js
+++ b/src/modules/ChatRoom.js
@@ -25,7 +25,7 @@ class ChatRoom extends React.Component {
       users: [],
       keyword: "",
       roomName: "Chat Room",
-      loading: true
+      loading: true,
     };
     this.dummy = createRef();
     this.handleChange = this.handleChange.bind(this);

--- a/src/modules/User.js
+++ b/src/modules/User.js
@@ -82,7 +82,7 @@ class User extends React.Component {
       this.setRoomId(participants, roomId);
       chatRoomId = roomId;
     }
-    this.props.handler(chatRoomId, this.user);
+    this.props.handler(chatRoomId, this.props.user);
   }
 
   /**


### PR DESCRIPTION
## Checklist

- [x] Did you write tests for your code?
- [x] Did all the tests pass locally?

## Trello Ticket

https://trello.com/c/hyLm1GVH/56-ui-polishing

## Short Description

This changes the room title from "Chat Room" to the display name of the other user that the current user is chatting with.

## Reviewer Notes

- This implementation assumes each chat is still just 1-to-1 messaging. I felt that because we probably will not get to group messaging, it was okay for this change to make the 1-to-1 messaging assumption. I think updating it to be more general wouldn't be too bad if we do end up getting to group messaging later.
- The added test checks that the display name of the user in the first room renders as the room name. To test the functionality that the room name successfully changes upon room change, the "Switch rooms" test was updated, which will now perform this check.